### PR TITLE
Fixed an MP4 AudioProperties parsing error

### DIFF
--- a/taglib/mp4/mp4properties.cpp
+++ b/taglib/mp4/mp4properties.cpp
@@ -195,8 +195,8 @@ MP4::AudioProperties::read(File *file, Atoms *atoms)
       debug("MP4: Atom 'trak.mdia.mdhd' is smaller than expected");
       return;
     }
-    unit   = data.toInt64BE(28);
-    length = data.toInt64BE(36);
+    unit   = data.toUInt32BE(28);
+    length = data.toInt64BE(32);
   }
   else {
     if(data.size() < 24 + 4) {


### PR DESCRIPTION
The 'unit' (timescale) of 'mdhd' v1 atoms is a 32-bit unsigned integer (4 bytes long), but is parsed as a 64-bit integer (8 bytes long). This also affects the byte offset of the 'length' (duration).  This results in MP4 AudioProperties reporting a track length of zero.

This change addresses both problems.

Resolves #891.

See:
https://wiki.multimedia.cx/index.php/QuickTime_container